### PR TITLE
fix: dart format CI failure (v1.2.0)

### DIFF
--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -1160,9 +1160,11 @@ class SystemError {
 
   factory SystemError.fromMap(Map<String, dynamic> map) => SystemError(
         code: map['code'] as String? ?? 'UNKNOWN',
-        message: map['message'] as String? ?? 'An unexpected native error occurred',
+        message:
+            map['message'] as String? ?? 'An unexpected native error occurred',
         timestamp: map['timestamp'] != null
-            ? DateTime.fromMillisecondsSinceEpoch((map['timestamp'] as num).toInt())
+            ? DateTime.fromMillisecondsSinceEpoch(
+                (map['timestamp'] as num).toInt())
             : DateTime.now(),
       );
 

--- a/test/unit/cold_start_persistence_test.dart
+++ b/test/unit/cold_start_persistence_test.dart
@@ -60,7 +60,8 @@ void main() {
 
     test('unregistered worker is not available', () {
       NativeWorkManager.registerDartWorker('workerA', _workerA);
-      expect(NativeWorkManager.isDartWorkerRegistered('unknownWorker'), isFalse);
+      expect(
+          NativeWorkManager.isDartWorkerRegistered('unknownWorker'), isFalse);
     });
 
     test('multiple workers registered simultaneously', () {
@@ -116,7 +117,8 @@ void main() {
       expect(worker.callbackId, 'workerA');
     });
 
-    test('FakeWorkManager returns accepted by default for DartWorker', () async {
+    test('FakeWorkManager returns accepted by default for DartWorker',
+        () async {
       final handler = await wm.enqueue(
         taskId: 'dart_task_2',
         worker: DartWorker(callbackId: 'workerA'),
@@ -126,7 +128,8 @@ void main() {
       expect(handler.scheduleResult, ScheduleResult.accepted);
     });
 
-    test('registered DartWorker callback is callable and returns true', () async {
+    test('registered DartWorker callback is callable and returns true',
+        () async {
       // handler.result requires NativeWorkManager.events (needs full init — integration only).
       // Unit test: call the callback function directly via its registration.
       expect(NativeWorkManager.isDartWorkerRegistered('workerA'), isTrue);


### PR DESCRIPTION
Fix dart format check failure on 2 files missed before the v1.2.0 merge.