### PR TITLE
fix(ios): resolve double-nested KMPWorkManager xcframework extraction (#33) + release v1.3.1

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -14,3 +14,14 @@ assets/
 coverage/
 test_results.txt
 doc/internal/
+extension/devtools/build/
+extension/devtools/.dart_tool/
+example/build/
+example/.dart_tool/
+example/android/.gradle/
+example/ios/Pods/
+example/ios/.symlinks/
+
+# XCFramework binary — distributed via GitHub Releases (downloaded by CocoaPods prepare_command).
+# Excluding keeps pub.dev package under the 100 MB limit.
+ios/Frameworks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.1] - 2026-06-07
+
+### Fixed
+- **iOS**: Fixed an issue where the `KMPWorkManager.xcframework` was extracted into a double-nested path (`Frameworks/Frameworks/KMPWorkManager.xcframework`) during `pod install`, causing iOS builds to fail with "Unable to find module dependency: 'KMPWorkManager'". The `prepare_command` in `native_workmanager.podspec` is now layout-agnostic (Resolves #33).
+
 ## [1.3.0] - 2026-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ No boilerplate. No native code to write. No `AndroidManifest.xml` changes. Each 
 
 ```yaml
 dependencies:
-  native_workmanager: ^1.3.0
+  native_workmanager: ^1.3.1
 ```
 
 **2. Initialize once in `main()`:**

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - native_workmanager (1.2.6):
+  - native_workmanager (1.3.0):
     - Flutter
   - shared_preferences_foundation (0.0.1):
     - Flutter
@@ -32,7 +32,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  native_workmanager: 75e6ac21372c2e78678cbc9b662396b20f7487ae
+  native_workmanager: 26304bd6e53f1968cd66eb9014f15f015c600532
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -261,7 +261,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.3.1"
   objective_c:
     dependency: transitive
     description:

--- a/ios/native_workmanager.podspec
+++ b/ios/native_workmanager.podspec
@@ -45,8 +45,13 @@ Features:
       mkdir -p Frameworks
       curl -L --retry 3 -o /tmp/KMPWorkManager.xcframework.zip \
         "https://github.com/brewkits/native_workmanager/releases/download/v1.3.0/KMPWorkManager.xcframework.zip"
-      cd Frameworks && unzip -o /tmp/KMPWorkManager.xcframework.zip && cd ..
-      rm -f /tmp/KMPWorkManager.xcframework.zip
+      rm -rf /tmp/kmpwm_extract
+      unzip -o /tmp/KMPWorkManager.xcframework.zip -d /tmp/kmpwm_extract
+      # Release zip may be flat or wrapped in a Frameworks/ dir - handle both.
+      SRC=$(find /tmp/kmpwm_extract -maxdepth 2 -type d -name 'KMPWorkManager.xcframework' | head -1)
+      rm -rf Frameworks/KMPWorkManager.xcframework
+      mv "$SRC" Frameworks/KMPWorkManager.xcframework
+      rm -rf /tmp/KMPWorkManager.xcframework.zip /tmp/kmpwm_extract
     fi
   CMD
   s.vendored_frameworks = 'Frameworks/KMPWorkManager.xcframework'

--- a/ios/native_workmanager.podspec
+++ b/ios/native_workmanager.podspec
@@ -37,7 +37,18 @@ Features:
   s.swift_version = '5.0'
 
   # KMP WorkManager Framework (kmpworkmanager v2.5.1)
-  # Tracked with Git LFS for efficient binary storage
+  # Downloaded from GitHub Releases to stay under the pub.dev 100 MB package limit.
+  s.prepare_command = <<-CMD
+    set -e
+    if [ ! -d "Frameworks/KMPWorkManager.xcframework" ]; then
+      echo "Downloading KMPWorkManager.xcframework v2.5.1..."
+      mkdir -p Frameworks
+      curl -L --retry 3 -o /tmp/KMPWorkManager.xcframework.zip \
+        "https://github.com/brewkits/native_workmanager/releases/download/v1.3.0/KMPWorkManager.xcframework.zip"
+      cd Frameworks && unzip -o /tmp/KMPWorkManager.xcframework.zip && cd ..
+      rm -f /tmp/KMPWorkManager.xcframework.zip
+    fi
+  CMD
   s.vendored_frameworks = 'Frameworks/KMPWorkManager.xcframework'
 
   # Privacy manifest for background task APIs (iOS 17+ App Store requirement)

--- a/native_workmanager_gen/CHANGELOG.md
+++ b/native_workmanager_gen/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.3.1] - 2026-06-07
+
+- Version bump synchronized with `native_workmanager` 1.3.1.
+
 ## [1.3.0] - 2026-06-04
 
 ### Changed

--- a/native_workmanager_gen/pubspec.yaml
+++ b/native_workmanager_gen/pubspec.yaml
@@ -1,5 +1,5 @@
 name: native_workmanager_gen
-version: 1.3.0
+version: 1.3.1
 description: >
   Code generator for native_workmanager.
   Generates type-safe DartWorker callback IDs and worker registry from

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_workmanager
 description: "Background task scheduling for Flutter — 25+ native workers (HTTP, image, crypto, file), task chains, zero Flutter Engine overhead."
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/brewkits/native_workmanager
 repository: https://github.com/brewkits/native_workmanager
 issue_tracker: https://github.com/brewkits/native_workmanager/issues

--- a/scripts/test_podspec_extraction.sh
+++ b/scripts/test_podspec_extraction.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+echo "=== Kiểm tra Logic Giải Nén của Podspec ==="
+
+# 1. Tạo môi trường giả lập framework
+rm -rf /tmp/mock_fw /tmp/mock_fw_nested
+mkdir -p /tmp/mock_fw/KMPWorkManager.xcframework/Headers
+touch /tmp/mock_fw/KMPWorkManager.xcframework/Headers/Mock.h
+
+# 2. Giả lập tạo Zip Phẳng (Flat Zip)
+cd /tmp/mock_fw
+zip -rq /tmp/flat_release.zip KMPWorkManager.xcframework
+
+# 3. Giả lập tạo Zip Lồng (Nested Zip - giống bản 1.3.0 trên Github)
+mkdir -p /tmp/mock_fw_nested/Frameworks
+cp -r /tmp/mock_fw/KMPWorkManager.xcframework /tmp/mock_fw_nested/Frameworks/
+cd /tmp/mock_fw_nested
+zip -rq /tmp/nested_release.zip Frameworks/
+
+echo "[✓] Đã tạo thành công 2 file zip giả lập (Flat và Nested)."
+echo ""
+
+# 4. Hàm thực thi y hệt logic trong podspec
+test_extraction() {
+  local zip_path=$1
+  local test_name=$2
+  
+  echo "--- Đang chạy test: $test_name ---"
+  
+  # Dọn dẹp trước khi chạy
+  rm -rf /tmp/test_workspace
+  mkdir -p /tmp/test_workspace/Frameworks
+  cd /tmp/test_workspace
+  
+  # ---- ĐOẠN LOGIC SAO CHÉP TỪ PODSPEC BẮT ĐẦU ----
+  rm -rf /tmp/kmpwm_extract
+  unzip -oq "$zip_path" -d /tmp/kmpwm_extract
+  # Release zip may be flat or wrapped in a Frameworks/ dir - handle both.
+  SRC=$(find /tmp/kmpwm_extract -maxdepth 2 -type d -name 'KMPWorkManager.xcframework' | head -1)
+  rm -rf Frameworks/KMPWorkManager.xcframework
+  mv "$SRC" Frameworks/KMPWorkManager.xcframework
+  rm -rf /tmp/kmpwm_extract
+  # ---- ĐOẠN LOGIC SAO CHÉP TỪ PODSPEC KẾT THÚC ----
+  
+  # Kiểm tra kết quả
+  if [ -d "Frameworks/KMPWorkManager.xcframework" ] && [ ! -d "Frameworks/Frameworks" ]; then
+    echo "[✓] THÀNH CÔNG: Kết quả trích xuất chuẩn xác ở 1 lớp Frameworks/KMPWorkManager.xcframework"
+  else
+    echo "[x] THẤT BẠI: Cấu trúc thư mục bị sai."
+    ls -R Frameworks
+    exit 1
+  fi
+  echo ""
+}
+
+# 5. Chạy test cho cả 2 trường hợp
+test_extraction "/tmp/flat_release.zip" "FILE ZIP PHẲNG (Zip không bọc Frameworks)"
+test_extraction "/tmp/nested_release.zip" "FILE ZIP LỒNG (Zip bọc sẵn Frameworks/ - Giống Github Release 1.3.0)"
+
+echo "=== TẤT CẢ TEST ĐỀU PASSED! ==="


### PR DESCRIPTION
## Summary
Fixes #33 — iOS builds of v1.3.0 fail with `Unable to find module dependency: 'KMPWorkManager'`.

### Root cause
The `KMPWorkManager.xcframework.zip` asset on the GitHub v1.3.0 release is wrapped in a leading `Frameworks/` directory. The old `prepare_command` did `cd Frameworks && unzip`, producing a double-nested path `Frameworks/Frameworks/KMPWorkManager.xcframework`, while the podspec declares `vendored_frameworks = 'Frameworks/KMPWorkManager.xcframework'`. CocoaPods therefore could not locate the framework.

### Fix
Rewrote `prepare_command` to be layout-agnostic: extract to a temp dir, `find` the `.xcframework` (handles both flat and `Frameworks/`-wrapped zips), and `mv` it into the canonical single-level location.

### Release
- Bump `version: 1.3.0 → 1.3.1` (pubspec.yaml)
- CHANGELOG entry for 1.3.1
- `native_workmanager_gen` bumped to 1.3.1 for ecosystem consistency
- README install snippet updated to `^1.3.1`

### Verification
- Downloaded the real v1.3.0 release zip and confirmed the wrapped `Frameworks/` layout
- `pod install` in `example/ios` succeeds; `Podfile.lock` checksum updated
- Added regression test `scripts/test_podspec_extraction.sh` covering flat + nested zip layouts (both pass)
- Example app builds and runs on iOS Simulator

Note: the podspec download URL intentionally remains pinned to the v1.3.0 release asset — the framework binary (kmpworkmanager 2.5.1) is unchanged; only the extraction script was broken.