### PR TITLE
fix(android): allow app sandbox under /data — repair file workers broken since v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.1] - 2026-06-07
 
 ### Fixed
+- **Android (critical regression, since v1.2.4)**: All file-based native workers
+  (`HttpDownload`, `HttpUpload`, `ParallelHttpDownload/Upload`, `FileCompression`,
+  `FileDecompression`, `ImageProcess`, `Crypto` hash/encrypt/decrypt, `Pdf`,
+  `WebSocket`, `FileSystem`, `MoveToSharedStorage`) failed on real devices with
+  "Invalid or unsafe file path". v1.2.4 added a blanket `"/data"` entry to
+  `SecurityValidator`'s blocked-prefix list, which rejected the app's own private
+  sandbox (`/data/data/<pkg>`, `/data/user/<n>/<pkg>` — exactly what `path_provider`
+  returns). The validator now blocks only the genuinely OS-owned sub-directories of
+  `/data` (`/data/local`, `/data/system`, `/data/misc`, `/data/app`, …) while
+  allowing the app sandbox. Path-traversal protection (canonical-path resolution)
+  and blocking of `/proc`, `/sys`, `/etc`, `/system`, `/vendor`, `/dev`, `/root`
+  are unchanged. Added `SecurityValidatorFilePathTest` (Kotlin) plus device
+  coverage in the "All Workers" integration group.
 - **iOS**: Fixed an issue where the `KMPWorkManager.xcframework` was extracted into a double-nested path (`Frameworks/Frameworks/KMPWorkManager.xcframework`) during `pod install`, causing iOS builds to fail with "Unable to find module dependency: 'KMPWorkManager'". The `prepare_command` in `native_workmanager.podspec` is now layout-agnostic (Resolves #33).
 
 ## [1.3.0] - 2026-06-04

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,12 +65,19 @@ android {
         testImplementation("org.mockito:mockito-core:5.0.0")
         testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
         testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+        // Robolectric + androidx.test for tests that need an Android runtime
+        // (NativeWorkManagerInitializerTest). Without these the unit-test source
+        // set fails to compile (unresolved RobolectricTestRunner / ApplicationProvider).
+        testImplementation("org.robolectric:robolectric:4.12.2")
+        testImplementation("androidx.test:core:1.5.0")
     }
 
     testOptions {
         unitTests {
             // Return default values for unmocked Android methods instead of throwing exceptions
             returnDefaultValues = true
+            // Required by Robolectric (NativeWorkManagerInitializerTest)
+            includeAndroidResources = true
 
             all {
                 testLogging {

--- a/android/src/main/kotlin/dev/brewkits/native_workmanager/workers/utils/SecurityValidator.kt
+++ b/android/src/main/kotlin/dev/brewkits/native_workmanager/workers/utils/SecurityValidator.kt
@@ -107,7 +107,23 @@ object SecurityValidator {
             val canonical = File(path).canonicalPath
             // Block read/write to OS-owned directories regardless of how the path
             // was constructed. This catches symlink escapes into system space.
-            val blockedPrefixes = listOf("/proc", "/sys", "/etc", "/system", "/vendor", "/dev", "/root", "/data")
+            //
+            // We intentionally do NOT block all of "/data". An app's own private
+            // sandbox lives under "/data/data/<pkg>" and "/data/user/<n>/<pkg>" —
+            // exactly what path_provider returns (getTemporaryDirectory,
+            // getApplicationDocumentsDirectory, ...). A blanket "/data" prefix
+            // therefore rejects every legitimate app file path and breaks all file
+            // workers. Cross-app and system access under /data is already prevented
+            // by the kernel uid sandbox, so we only block the genuinely OS-owned
+            // sub-directories of /data here.
+            // Regression note: a blanket "/data" entry shipped in v1.2.4 and broke
+            // every file worker (download/upload/compress/image/crypto). Do NOT
+            // re-add a bare "/data" prefix.
+            val blockedPrefixes = listOf(
+                "/proc", "/sys", "/etc", "/system", "/vendor", "/dev", "/root",
+                "/data/local", "/data/system", "/data/misc", "/data/app",
+                "/data/dalvik-cache", "/data/anr", "/data/tombstones",
+            )
             for (blocked in blockedPrefixes) {
                 if (canonical.startsWith(blocked)) {
                     Log.e(TAG, "File path '$canonical' points to restricted system directory '$blocked'")

--- a/android/src/test/kotlin/dev/brewkits/native_workmanager/NativeWorkManagerInitializerTest.kt
+++ b/android/src/test/kotlin/dev/brewkits/native_workmanager/NativeWorkManagerInitializerTest.kt
@@ -23,6 +23,7 @@ class NativeWorkManagerInitializerTest {
         context = ApplicationProvider.getApplicationContext()
         // Reset state before each test
         NativeWorkmanagerPlugin.isSchedulerInitialized = false
+        NativeWorkmanagerPlugin.isKmpInitialized = false
         FlutterEngineManager.registerPlugins = false
     }
 
@@ -75,14 +76,23 @@ class NativeWorkManagerInitializerTest {
         initializer.create(context)
 
         // Assert
+        // The initializer signals KMP init via isKmpInitialized (so the later
+        // initializeScheduler() can skip re-initializing KmpWorkManager). It must
+        // NOT set isSchedulerInitialized — the production code deliberately leaves
+        // that false so initializeScheduler() still runs to build NativeTaskScheduler
+        // (required for Exact/Windowed/ContentUri triggers). See the explicit
+        // "Do NOT set isSchedulerInitialized here" comment in NativeWorkManagerInitializer.
         assertTrue(
-            "Initializer must set isSchedulerInitialized to true", 
+            "Initializer must set isKmpInitialized to true after KmpWorkManager.initialize()",
+            NativeWorkmanagerPlugin.isKmpInitialized
+        )
+        assertFalse(
+            "Initializer must NOT set isSchedulerInitialized — initializeScheduler() must still run",
             NativeWorkmanagerPlugin.isSchedulerInitialized
         )
         assertTrue(
             "FlutterEngineManager.registerPlugins must be read from SharedPreferences",
             FlutterEngineManager.registerPlugins
         )
-        // callbackHandle is private, so we assume if isSchedulerInitialized is true, it read it.
     }
 }

--- a/android/src/test/kotlin/dev/brewkits/native_workmanager/workers/SecurityValidatorFilePathTest.kt
+++ b/android/src/test/kotlin/dev/brewkits/native_workmanager/workers/SecurityValidatorFilePathTest.kt
@@ -1,0 +1,121 @@
+package dev.brewkits.native_workmanager.workers
+
+import dev.brewkits.native_workmanager.workers.utils.SecurityValidator
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for [SecurityValidator.validateFilePathSafe].
+ *
+ * v1.2.4 added a blanket "/data" prefix to the blocked list, which rejected every
+ * app-private path (path_provider returns paths under /data/data/<pkg> and
+ * /data/user/<n>/<pkg>). That broke all file workers (download/upload/compress/
+ * image/crypto) on real Android devices. These tests pin the corrected behaviour:
+ * the app sandbox under /data is allowed, while genuinely OS-owned directories
+ * (including the sensitive sub-dirs of /data) stay blocked.
+ */
+class SecurityValidatorFilePathTest {
+
+    // --- App-private sandbox paths MUST be allowed (the regression) ---
+
+    @Test
+    fun `app code_cache under data data is allowed`() {
+        assertTrue(
+            SecurityValidator.validateFilePathSafe(
+                "/data/data/dev.brewkits.native_workmanager_example/code_cache/out.txt",
+            ),
+        )
+    }
+
+    @Test
+    fun `app cache under data user is allowed`() {
+        assertTrue(
+            SecurityValidator.validateFilePathSafe(
+                "/data/user/0/dev.brewkits.native_workmanager_example/cache/download.json",
+            ),
+        )
+    }
+
+    @Test
+    fun `app files dir under data data is allowed`() {
+        assertTrue(
+            SecurityValidator.validateFilePathSafe(
+                "/data/data/com.example.app/files/report.pdf",
+            ),
+        )
+    }
+
+    @Test
+    fun `external app storage is allowed`() {
+        assertTrue(
+            SecurityValidator.validateFilePathSafe(
+                "/storage/emulated/0/Android/data/com.example.app/files/photo.png",
+            ),
+        )
+    }
+
+    // --- Genuinely OS-owned directories MUST stay blocked ---
+
+    @Test
+    fun `data local tmp is blocked`() {
+        assertFalse(SecurityValidator.validateFilePathSafe("/data/local/tmp/payload.sh"))
+    }
+
+    @Test
+    fun `data system is blocked`() {
+        assertFalse(SecurityValidator.validateFilePathSafe("/data/system/packages.xml"))
+    }
+
+    @Test
+    fun `data misc is blocked`() {
+        assertFalse(SecurityValidator.validateFilePathSafe("/data/misc/keystore/key"))
+    }
+
+    @Test
+    fun `proc is blocked`() {
+        assertFalse(SecurityValidator.validateFilePathSafe("/proc/self/maps"))
+    }
+
+    @Test
+    fun `sys is blocked`() {
+        assertFalse(SecurityValidator.validateFilePathSafe("/sys/kernel/debug"))
+    }
+
+    @Test
+    fun `vendor is blocked`() {
+        assertFalse(SecurityValidator.validateFilePathSafe("/vendor/bin/foo"))
+    }
+
+    // Note: /etc and /system are also in the blocked list and work correctly on
+    // an Android device, but they are NOT unit-tested here because these tests run
+    // on the host JVM, where File.canonicalPath resolves them against the host
+    // filesystem (on macOS /etc -> /private/etc via symlink, and /system -> /System
+    // via the case-insensitive APFS), so the canonical path no longer carries the
+    // blocked prefix. The traversal test below still exercises /system blocking via
+    // a literal (non-existent) path that canonicalPath leaves untouched.
+
+    // --- Traversal escapes out of the sandbox into system space stay blocked ---
+
+    @Test
+    fun `traversal from app dir into system is blocked`() {
+        // canonicalPath collapses the ".." segments to "/system/build.prop".
+        assertFalse(
+            SecurityValidator.validateFilePathSafe(
+                "/data/data/com.example.app/../../../system/build.prop",
+            ),
+        )
+    }
+
+    // --- Basic input validation ---
+
+    @Test
+    fun `empty path is rejected`() {
+        assertFalse(SecurityValidator.validateFilePathSafe(""))
+    }
+
+    @Test
+    fun `relative path is rejected`() {
+        assertFalse(SecurityValidator.validateFilePathSafe("relative/path/file.txt"))
+    }
+}

--- a/example/integration_test/device_integration_test.dart
+++ b/example/integration_test/device_integration_test.dart
@@ -39,29 +39,65 @@ import 'package:native_workmanager/native_workmanager.dart';
 String _id(String name) =>
     'dit_${name}_${DateTime.now().millisecondsSinceEpoch}';
 
-/// Subscribes to [NativeWorkManager.events] and resolves when the
-/// first matching event for [taskId] arrives, or returns null on timeout.
-/// Subscribes to [NativeWorkManager.events] and resolves when the first
-/// matching event for [taskId] arrives, or returns null on timeout.
+// ──────────────────────────────────────────────────────────────
+// Shared event hub
+//
+// Earlier every _waitEvent() opened its own NativeWorkManager.events
+// subscription (plus a Future.delayed timeout timer) and cancelled it on match.
+// Across a full ~60-test run this left many lingering listeners and timers and
+// made back-to-back tests flaky (events for one test occasionally missed) and
+// eventually wedged the run. A single long-lived subscription that routes
+// terminal events to per-taskId waiters — and buffers terminal events that
+// arrive before their waiter registers — removes that whole class of races.
+// ──────────────────────────────────────────────────────────────
+
+StreamSubscription<TaskEvent>? _eventHubSub;
+final Map<String, Completer<TaskEvent?>> _eventWaiters = {};
+final Map<String, TaskEvent> _eventBuffer = {};
+
+void _startEventHub() {
+  _eventHubSub ??= NativeWorkManager.events.listen((event) {
+    // Only terminal events resolve a waiter; "started" is a lifecycle event.
+    if (event.isStarted) return;
+    final waiter = _eventWaiters.remove(event.taskId);
+    if (waiter != null && !waiter.isCompleted) {
+      waiter.complete(event);
+    } else {
+      // No waiter yet (event raced ahead of _waitEvent) or nobody is waiting:
+      // keep the latest terminal event so a slightly-late _waitEvent still sees it.
+      _eventBuffer[event.taskId] = event;
+    }
+  });
+}
+
+Future<void> _stopEventHub() async {
+  await _eventHubSub?.cancel();
+  _eventHubSub = null;
+  for (final w in _eventWaiters.values) {
+    if (!w.isCompleted) w.complete(null);
+  }
+  _eventWaiters.clear();
+  _eventBuffer.clear();
+}
+
+/// Resolves when the first terminal event for [taskId] arrives, or returns null
+/// on timeout. Backed by the shared [_startEventHub] subscription.
 ///
 /// Default timeout is 60 s — generous enough for real-device WorkManager
 /// scheduling variability while still catching genuine hangs.
 Future<TaskEvent?> _waitEvent(
   String taskId, {
   Duration timeout = const Duration(seconds: 60),
-}) async {
+}) {
+  // The event may already have arrived before this call (buffered by the hub).
+  final buffered = _eventBuffer.remove(taskId);
+  if (buffered != null) return Future.value(buffered);
+
   final completer = Completer<TaskEvent?>();
-  late StreamSubscription<TaskEvent> sub;
-  sub = NativeWorkManager.events.listen((event) {
-    // Skip "task started" lifecycle events — only complete on terminal events.
-    if (event.taskId == taskId && !completer.isCompleted && !event.isStarted) {
-      completer.complete(event);
-      sub.cancel();
-    }
-  });
+  _eventWaiters[taskId] = completer;
   Future.delayed(timeout, () {
     if (!completer.isCompleted) {
-      sub.cancel();
+      _eventWaiters.remove(taskId);
       completer.complete(null);
     }
   });
@@ -181,10 +217,22 @@ void main() {
 
     // Cancel any leftover tasks from previous runs.
     await NativeWorkManager.cancelAll();
+
+    // One long-lived event subscription for the whole suite (see _startEventHub).
+    _startEventHub();
+  });
+
+  // Drain the WorkManager queue after every test so delayed/periodic tasks
+  // enqueued by one test do not fire mid-way through a later test (which booted
+  // the Flutter engine for DartWorker callbacks and contended for resources,
+  // causing cross-test flakiness and the full-suite hang).
+  tearDown(() async {
+    await NativeWorkManager.cancelAll();
   });
 
   tearDownAll(() async {
     await NativeWorkManager.cancelAll();
+    await _stopEventHub();
     tmpDir.deleteSync(recursive: true);
   });
 


### PR DESCRIPTION
## Summary
Critical Android regression (since **v1.2.4**): **all file-based native workers** failed on real devices with `Invalid or unsafe file path`.

### Root cause
`SecurityValidator.validateFilePathSafe` had a blanket `"/data"` entry in its blocked-prefix list (added in v1.2.4). But the app's own private sandbox lives under `/data/data/<pkg>` and `/data/user/<n>/<pkg>` — exactly what `path_provider` returns (`getTemporaryDirectory`, `getApplicationDocumentsDirectory`, …). So every legitimate app file path was rejected.

Affected workers: `HttpDownload`, `HttpUpload`, `ParallelHttpDownload/Upload`, `FileCompression`, `FileDecompression`, `ImageProcess`, `Crypto` (hash/encrypt/decrypt), `Pdf`, `WebSocket`, `FileSystem`, `MoveToSharedStorage`.

### Fix
Block only the genuinely OS-owned sub-directories of `/data` (`/data/local`, `/data/system`, `/data/misc`, `/data/app`, …) and allow the app sandbox. Cross-app/system access under `/data` is already prevented by the kernel uid sandbox. Path-traversal protection (canonical-path resolution) and blocking of `/proc`, `/sys`, `/etc`, `/system`, `/vendor`, `/dev`, `/root` are unchanged.

### Verification
- **Device (Pixel 6 Pro, Android 16):** `All Workers` integration group **15/15**; logcat shows `KmpWorker success` for every worker (was `Invalid or unsafe file path`).
- **Kotlin unit:** new `SecurityValidatorFilePathTest` 13/13 (app-sandbox-allowed, OS-dir-blocked, traversal escape).
- `flutter analyze`: clean.

### Also in this PR
- `build.gradle`: add `robolectric` + `androidx.test` so the unit-test source set compiles (`NativeWorkManagerInitializerTest` referenced them but they were never declared).
- Fix `NativeWorkManagerInitializerTest`: it asserted `isSchedulerInitialized=true`, but the initializer deliberately sets `isKmpInitialized` and leaves `isSchedulerInitialized` false so `initializeScheduler()` still runs.
- `device_integration_test`: route `_waitEvent` through one long-lived event subscription and drain the WorkManager queue in `tearDown` — removes cross-test event-delivery flakiness (verified: Constraints 5/5, Cancellation 2/2, both previously failing/hanging cross-test).

### Note on full-suite run
The full 63-test device suite cannot be run end-to-end in one process on this machine due to inherently slow periodic tests (Android 16 defers periodic first-execution ~2 min each) plus VM-service instability over long runs — environmental, not a product issue. Verified by running each group individually; all pass.